### PR TITLE
fix: updating github actions with correct docker repo

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,amd64
+          platforms: arm64,amd64,arm/v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: your-docker-username/printer-smtp-server:pr-${{ github.event.number }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: dsmithson/printersmtpserver:pr-${{ github.event.number }}
           push: false
 
       - name: Push Docker image to registry
@@ -49,11 +49,11 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            your-docker-username/printer-smtp-server:latest
-            your-docker-username/printer-smtp-server:${{ github.sha }}
+            dsmithson/printersmtpserver:latest
+            dsmithson/printersmtpserver:${{ github.sha }}
 
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,amd64,arm/v7
+          platforms: arm64,amd64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -39,7 +39,7 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: dsmithson/printersmtpserver:pr-${{ github.event.number }}
           push: false
 
@@ -49,7 +49,7 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             dsmithson/printersmtpserver:latest


### PR DESCRIPTION
I left default repo names from some ChatGPT workflow template, and in this MR I'm looking to update that.